### PR TITLE
Bump resource version for skupper controller

### DIFF
--- a/skupper/base/site-controller/kustomization.yaml
+++ b/skupper/base/site-controller/kustomization.yaml
@@ -4,4 +4,4 @@ kind: Kustomization
 
 resources:
   - 01-install.yaml
-  - https://raw.githubusercontent.com/skupperproject/skupper/0.8.6/cmd/site-controller/deploy-watch-current-ns.yaml
+  - https://raw.githubusercontent.com/skupperproject/skupper/master/cmd/site-controller/deploy-watch-current-ns.yaml


### PR DESCRIPTION
there is hard coded 0.8.6 version of site-controller image being used here. That lead to problems while I tried the demo. Go had segmentation fault repeatedly, and the demo didn't work:

```
2022/12/22 15:24:00 Checking if sites need updates (0.8.6)
E1222
 15:24:00.334513       1 runtime.go:78] Observed a panic: "invalid 
memory address or nil pointer dereference" (runtime error: invalid 
memory address or nil pointer dereference)
goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x14a6460, 0x22f4fc0)
    /go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
    /go/pkg/mod/k8s.io/apimachinery@v0.17.0/pkg/util/runtime/runtime.go:48 +0x82
panic(0x14a6460, 0x22f4fc0)
    /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/skupperproject/skupper/pkg/qdr.(*RouterConfig).GetSiteMetadata(...)
    /go/src/app/pkg/qdr/qdr.go:166
github.com/skupperproject/skupper/client.(*VanClient).RouterUpdateVersionInNamespace(0xc000366000,
 0x1877260, 0xc0000c0208, 0x0, 0xc0003b33c0, 0xe, 0xc0000e1dd8, 
0xc0000c6000, 0x26)
    /go/src/app/client/router_update.go:79 +0x129
main.(*SiteController).updateChecks(0xc0003664c0)
    /go/src/app/cmd/site-controller/controller.go:393 +0xff
main.(*SiteController).Run(0xc0003664c0, 0xc00009e660, 0x0, 0x0)
    /go/src/app/cmd/site-controller/controller.go:119 +0x2ee
main.main()
    /go/src/app/cmd/site-controller/main.go:64 +0x1c6
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x132a429]
```

I found the hard coded version in yaml pointed by kustomize config, and checked the most recent uses :master tagged image. Changed to point to such up to date yaml fixed the issue by upgrading the container.